### PR TITLE
Regex JSON modifier

### DIFF
--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03A157A022FD66B700A60090 /* TWUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70D2FF162271F9C7008B37F4 /* TWUITests.framework */; };
+		03A157A722FD952C00A60090 /* RegexJSONModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */; };
+		03A157A922FD954E00A60090 /* RegexJSONModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A157A822FD954E00A60090 /* RegexJSONModifier.swift */; };
 		1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */; };
 		1FE86220228D7197003EA159 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF8B227319DE008B37F4 /* AccessibilityIdentifiers.swift */; };
 		70D2FF1B2271F9C7008B37F4 /* TWUITests.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D2FF192271F9C7008B37F4 /* TWUITests.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -48,6 +51,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		03A157A122FD66B700A60090 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 70D2FF0D2271F9C7008B37F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 70D2FF152271F9C7008B37F4;
+			remoteInfo = TWUITests;
+		};
 		70D2FF392271F9D4008B37F4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 70D2FF0D2271F9C7008B37F4 /* Project object */;
@@ -58,6 +68,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03A1579B22FD66B700A60090 /* TWUITestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TWUITestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		03A1579F22FD66B700A60090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexJSONModifierTests.swift; sourceTree = "<group>"; };
+		03A157A822FD954E00A60090 /* RegexJSONModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexJSONModifier.swift; sourceTree = "<group>"; };
 		1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
 		70D2FF162271F9C7008B37F4 /* TWUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TWUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D2FF192271F9C7008B37F4 /* TWUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TWUITests.h; sourceTree = "<group>"; };
@@ -102,6 +116,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		03A1579822FD66B700A60090 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03A157A022FD66B700A60090 /* TWUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70D2FF132271F9C7008B37F4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -130,10 +152,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03A1579C22FD66B700A60090 /* TWUITestsTests */ = {
+			isa = PBXGroup;
+			children = (
+				03A1579F22FD66B700A60090 /* Info.plist */,
+				03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */,
+			);
+			path = TWUITestsTests;
+			sourceTree = "<group>";
+		};
 		70D2FF0C2271F9C7008B37F4 = {
 			isa = PBXGroup;
 			children = (
 				70D2FF182271F9C7008B37F4 /* TWUITests */,
+				03A1579C22FD66B700A60090 /* TWUITestsTests */,
 				70D2FF262271F9D4008B37F4 /* Example */,
 				70D2FF3B2271F9D5008B37F4 /* ExampleUITests */,
 				70D2FF172271F9C7008B37F4 /* Products */,
@@ -147,6 +179,7 @@
 				70D2FF162271F9C7008B37F4 /* TWUITests.framework */,
 				70D2FF252271F9D4008B37F4 /* Example.app */,
 				70D2FF382271F9D4008B37F4 /* ExampleUITests.xctest */,
+				03A1579B22FD66B700A60090 /* TWUITestsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -205,6 +238,7 @@
 			children = (
 				70D2FF4C227202C6008B37F4 /* HTTPDynamicStubbs.swift */,
 				70D2FF4E227202D7008B37F4 /* HTTPStubsList.swift */,
+				03A157A822FD954E00A60090 /* RegexJSONModifier.swift */,
 			);
 			path = APIStubs;
 			sourceTree = "<group>";
@@ -295,6 +329,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		03A1579A22FD66B700A60090 /* TWUITestsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03A157A522FD66B700A60090 /* Build configuration list for PBXNativeTarget "TWUITestsTests" */;
+			buildPhases = (
+				03A1579722FD66B700A60090 /* Sources */,
+				03A1579822FD66B700A60090 /* Frameworks */,
+				03A1579922FD66B700A60090 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				03A157A222FD66B700A60090 /* PBXTargetDependency */,
+			);
+			name = TWUITestsTests;
+			productName = TWUITestsTests;
+			productReference = 03A1579B22FD66B700A60090 /* TWUITestsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		70D2FF152271F9C7008B37F4 /* TWUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 70D2FF1E2271F9C7008B37F4 /* Build configuration list for PBXNativeTarget "TWUITests" */;
@@ -360,6 +412,9 @@
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Treatwell;
 				TargetAttributes = {
+					03A1579A22FD66B700A60090 = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 					70D2FF152271F9C7008B37F4 = {
 						CreatedOnToolsVersion = 10.2.1;
 						LastSwiftMigration = 1020;
@@ -387,6 +442,7 @@
 			projectRoot = "";
 			targets = (
 				70D2FF152271F9C7008B37F4 /* TWUITests */,
+				03A1579A22FD66B700A60090 /* TWUITestsTests */,
 				70D2FF242271F9D4008B37F4 /* Example */,
 				70D2FF372271F9D4008B37F4 /* ExampleUITests */,
 			);
@@ -394,6 +450,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		03A1579922FD66B700A60090 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70D2FF142271F9C7008B37F4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -462,6 +525,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		03A1579722FD66B700A60090 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03A157A722FD952C00A60090 /* RegexJSONModifierTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		70D2FF122271F9C7008B37F4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -472,6 +543,7 @@
 				70D2FF572272E9C4008B37F4 /* PageObjectModel.swift in Sources */,
 				70D2FF622272EAFB008B37F4 /* UITestCase+Given.swift in Sources */,
 				70D2FF692272EC0E008B37F4 /* XCTestCase+Extensions.swift in Sources */,
+				03A157A922FD954E00A60090 /* RegexJSONModifier.swift in Sources */,
 				70D2FF5422720372008B37F4 /* APIStubInfo.swift in Sources */,
 				70D2FF602272EAC2008B37F4 /* UITestApplication+Then.swift in Sources */,
 				70D2FF5D2272EA89008B37F4 /* UITestApplication.swift in Sources */,
@@ -516,6 +588,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		03A157A222FD66B700A60090 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 70D2FF152271F9C7008B37F4 /* TWUITests */;
+			targetProxy = 03A157A122FD66B700A60090 /* PBXContainerItemProxy */;
+		};
 		70D2FF3A2271F9D4008B37F4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 70D2FF242271F9D4008B37F4 /* Example */;
@@ -543,6 +620,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		03A157A322FD66B700A60090 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = X5394XCRFK;
+				INFOPLIST_FILE = TWUITestsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.treatwell.TWUITests.TWUITestsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		03A157A422FD66B700A60090 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = X5394XCRFK;
+				INFOPLIST_FILE = TWUITestsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.treatwell.TWUITests.TWUITestsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		70D2FF1C2271F9C7008B37F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -820,6 +935,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		03A157A522FD66B700A60090 /* Build configuration list for PBXNativeTarget "TWUITestsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03A157A322FD66B700A60090 /* Debug */,
+				03A157A422FD66B700A60090 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		70D2FF102271F9C7008B37F4 /* Build configuration list for PBXProject "TWUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/TWUITests.xcodeproj/xcshareddata/xcschemes/TWUITests.xcscheme
+++ b/TWUITests.xcodeproj/xcshareddata/xcschemes/TWUITests.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03A1579A22FD66B700A60090"
+               BuildableName = "TWUITestsTests.xctest"
+               BlueprintName = "TWUITestsTests"
+               ReferencedContainer = "container:TWUITests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "70D2FF152271F9C7008B37F4"
+            BuildableName = "TWUITests.framework"
+            BlueprintName = "TWUITests"
+            ReferencedContainer = "container:TWUITests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/TWUITests/APIStubs/HTTPDynamicStubbs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubbs.swift
@@ -63,17 +63,16 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
 
     func replace(with modification: RegexJSONModifier.Modification, in stub: APIStubInfo) {
         transform({
-            self.regexModifier.apply(modification: modification, in: $0)
+            try self.regexModifier.apply(modification: modification, in: $0)
         }, in: stub)
     }
 
-    private func transform(_ modifyFn: (Data) -> Data?, in stub: APIStubInfo) {
+    private func transform(_ modifyFn: (Data) throws -> Data, in stub: APIStubInfo) {
         do {
             let dataObject = getDataObject(from: stub)
             guard let json = dataToJSON(data: dataObject) else { return }
             let data = try JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions.prettyPrinted)
-            guard let modifiedData = modifyFn(data) else { return }
-            stubJSON(object: modifiedData, for: stub)
+            stubJSON(object: try modifyFn(data), for: stub)
         } catch let error {
             print(error)
         }

--- a/TWUITests/APIStubs/HTTPDynamicStubbs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubbs.swift
@@ -19,8 +19,7 @@ protocol HTTPDynamicStubing {
     func update(with stubInfo: APIStubInfo)
     func start()
     func stop()
-    func replaceValues(of items: [String: String], in stub: APIStubInfo)
-    func replaceValues(withOldToNewMap: [String: String], in stub: APIStubInfo)
+    func replace(with modification: RegexJSONModifier.Modification, in stub: APIStubInfo)
 }
 
 final class HTTPDynamicStubs: HTTPDynamicStubing {
@@ -62,15 +61,9 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         setupStub(stubInfo)
     }
 
-    func replaceValues(of items: [String: String], in stub: APIStubInfo) {
+    func replace(with modification: RegexJSONModifier.Modification, in stub: APIStubInfo) {
         transform({
-            self.regexModifier.apply(modification: .replaceKeyValues(items), in: $0)
-        }, in: stub)
-    }
-
-    func replaceValues(withOldToNewMap oldToNewMap: [String: String], in stub: APIStubInfo) {
-        transform({
-            self.regexModifier.apply(modification: .replaceValues(oldToNewMap), in: $0)
+            self.regexModifier.apply(modification: modification, in: $0)
         }, in: stub)
     }
 

--- a/TWUITests/APIStubs/RegexJSONModifier.swift
+++ b/TWUITests/APIStubs/RegexJSONModifier.swift
@@ -1,0 +1,36 @@
+//  Copyright 2019 Hotspring Ventures Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+struct RegexJSONModifier {
+    enum Modification {
+        case replaceKeyValues([String: String])
+    }
+
+    func apply(modification: Modification, in input: Data) -> Data? {
+        guard var string = String(data: input, encoding: .utf8) else { return nil }
+
+        switch modification {
+        case let .replaceKeyValues(items):
+            for (key, value) in items {
+                string = string.replacingOccurrences(
+                    of: "\"\(key)\"\\s?:\\s?\".*\"",
+                    with: "\"\(key)\" : \"\(value)\"",
+                    options: .regularExpression)
+            }
+        }
+        return string.data(using: .utf8)
+    }
+}

--- a/TWUITests/APIStubs/RegexJSONModifier.swift
+++ b/TWUITests/APIStubs/RegexJSONModifier.swift
@@ -17,6 +17,7 @@ import Foundation
 struct RegexJSONModifier {
     enum Modification {
         case replaceKeyValues([String: String])
+        case replaceValues([String: String])
     }
 
     func apply(modification: Modification, in input: Data) -> Data? {
@@ -28,6 +29,13 @@ struct RegexJSONModifier {
                 string = string.replacingOccurrences(
                     of: "\"\(key)\"\\s?:\\s?\".*\"",
                     with: "\"\(key)\" : \"\(value)\"",
+                    options: .regularExpression)
+            }
+        case let .replaceValues(items):
+            for (oldVal, newVal) in items {
+                string = string.replacingOccurrences(
+                    of: ":\\s?\"\(oldVal)\"",
+                    with: ": \"\(newVal)\"",
                     options: .regularExpression)
             }
         }

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -36,11 +36,13 @@ public final class UITestApplication: XCUIApplication {
     }
 
     public func replaceValues(withOldToNewMap oldToNewMap: [String: String], in stub: APIStubInfo) {
-        server?.replaceValues(withOldToNewMap: oldToNewMap, in: stub)
+        let modification = RegexJSONModifier.Modification.replaceValues(oldToNewMap)
+        server?.replace(with: modification, in: stub)
     }
 
     public func replaceValues(of items: [String: String], in stub: APIStubInfo) {
-        server?.replaceValues(of: items, in: stub)
+        let modification = RegexJSONModifier.Modification.replaceKeyValues(items)
+        server?.replace(with: modification, in: stub)
     }
 }
 

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -35,6 +35,10 @@ public final class UITestApplication: XCUIApplication {
         replaceValues(of: [key: value], in: stub)
     }
 
+    public func replaceValues(withOldToNewMap oldToNewMap: [String: String], in stub: APIStubInfo) {
+        server?.replaceValues(withOldToNewMap: oldToNewMap, in: stub)
+    }
+
     public func replaceValues(of items: [String: String], in stub: APIStubInfo) {
         server?.replaceValues(of: items, in: stub)
     }

--- a/TWUITestsTests/Info.plist
+++ b/TWUITestsTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TWUITestsTests/RegexJSONModifierTests.swift
+++ b/TWUITestsTests/RegexJSONModifierTests.swift
@@ -15,15 +15,10 @@
 import XCTest
 @testable import TWUITests
 
-class TWUITestsTests: XCTestCase {
+class RegexJSONModifierTests: XCTestCase {
 
-    private var modifier: RegexJSONModifier!
-    private var jsonInput: Data!
-
-    override func setUp() {
-        super.setUp()
-        modifier = RegexJSONModifier()
-        jsonInput = """
+    private var sut: RegexJSONModifier!
+    private var jsonInput = """
         {
             "k1" : "v1",
             "k2" : "v4",
@@ -33,22 +28,25 @@ class TWUITestsTests: XCTestCase {
                 "k3" : "v1"
             }]
         }
-        """.data(using: .utf8) ?? Data()
+        """.data(using: .utf8)!
+
+    override func setUp() {
+        super.setUp()
+        sut = RegexJSONModifier()
     }
 
     override func tearDown() {
-        modifier = nil
-        jsonInput = nil
+        sut = nil
         super.tearDown()
     }
 
-    func testKeyValuesReplacement() {
-        let result = modifier.apply(modification: .replaceKeyValues([
+    func testKeyValuesReplacement() throws {
+        let result = try sut.apply(modification: .replaceKeyValues([
             "k1": "v9",
             "k9": "v99",
             "k3": "v13"
         ]), in: jsonInput)
-        let resultStr = String(data: result ?? Data(), encoding: .utf8)
+        let resultStr = String(data: result, encoding: .utf8)
         let exp = """
         {
             "k1" : "v9",
@@ -63,13 +61,13 @@ class TWUITestsTests: XCTestCase {
         XCTAssertEqual(resultStr, exp)
     }
 
-    func testValuesReplacement() {
-        let result = modifier.apply(modification: .replaceValues([
+    func testValuesReplacement() throws {
+        let result = try sut.apply(modification: .replaceValues([
             "v4": "v99",
             "k2": "v77",
             "v3": "v90"
         ]), in: jsonInput)
-        let resultStr = String(data: result ?? Data(), encoding: .utf8)
+        let resultStr = String(data: result, encoding: .utf8)
         let exp = """
         {
             "k1" : "v1",

--- a/TWUITestsTests/RegexJSONModifierTests.swift
+++ b/TWUITestsTests/RegexJSONModifierTests.swift
@@ -1,0 +1,65 @@
+//  Copyright 2019 Hotspring Ventures Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import TWUITests
+
+class TWUITestsTests: XCTestCase {
+
+    private var modifier: RegexJSONModifier!
+    private var jsonInput: Data!
+
+    override func setUp() {
+        super.setUp()
+        modifier = RegexJSONModifier()
+        jsonInput = """
+        {
+            "k1" : "v1",
+            "k2" : "v4",
+            "k4" : [{
+                "k1" : "v4",
+                "k4" : "v3",
+                "k3" : "v1"
+            }]
+        }
+        """.data(using: .utf8) ?? Data()
+    }
+
+    override func tearDown() {
+        modifier = nil
+        jsonInput = nil
+        super.tearDown()
+    }
+
+    func testKeyValuesReplacement() {
+        let result = modifier.apply(modification: .replaceKeyValues([
+            "k1": "v9",
+            "k9": "v99",
+            "k3": "v13"
+        ]), in: jsonInput)
+        let resultStr = String(data: result ?? Data(), encoding: .utf8)
+        let exp = """
+        {
+            "k1" : "v9",
+            "k2" : "v4",
+            "k4" : [{
+                "k1" : "v9",
+                "k4" : "v3",
+                "k3" : "v13"
+            }]
+        }
+        """
+        XCTAssertEqual(resultStr, exp)
+    }
+}

--- a/TWUITestsTests/RegexJSONModifierTests.swift
+++ b/TWUITestsTests/RegexJSONModifierTests.swift
@@ -62,4 +62,25 @@ class TWUITestsTests: XCTestCase {
         """
         XCTAssertEqual(resultStr, exp)
     }
+
+    func testValuesReplacement() {
+        let result = modifier.apply(modification: .replaceValues([
+            "v4": "v99",
+            "k2": "v77",
+            "v3": "v90"
+        ]), in: jsonInput)
+        let resultStr = String(data: result ?? Data(), encoding: .utf8)
+        let exp = """
+        {
+            "k1" : "v1",
+            "k2" : "v99",
+            "k4" : [{
+                "k1" : "v99",
+                "k4" : "v90",
+                "k3" : "v1"
+            }]
+        }
+        """
+        XCTAssertEqual(resultStr, exp)
+    }
 }


### PR DESCRIPTION
Moved regex key-values replacement code to separate `RegexJSONModifier` structure which is unit tested.

Introduced new values replacement method to change "tokens" in JSON.