### PR TITLE
Add random port retry functionality

### DIFF
--- a/ExampleUITests/Tests Support/Configuration.swift
+++ b/ExampleUITests/Tests Support/Configuration.swift
@@ -16,9 +16,9 @@ import TWUITests
 
 final class Configuration: TWUITests.Configuration {
     var apiConfiguration: APIConfiguration = APIConfiguration(
-        port: 4567,
         portRange: 9000...9999,
-        apiStubs: []// Add defaults API stubs here)
+        apiStubs: [],   // Add defaults API stubs here
+        appID: ""       // appID is used to specify stubs path
     )
 
     var dictionary: [String: String] = [

--- a/ExampleUITests/Tests Support/Configuration.swift
+++ b/ExampleUITests/Tests Support/Configuration.swift
@@ -17,6 +17,7 @@ import TWUITests
 final class Configuration: TWUITests.Configuration {
     var apiConfiguration: APIConfiguration = APIConfiguration(
         port: 4567,
+        portRange: 9000...9999,
         apiStubs: []// Add defaults API stubs here)
     )
 

--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1F1628A023378D0B002DE2BF /* PortSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16289F23378D0B002DE2BF /* PortSettings.swift */; };
 		1F1628A223378D4E002DE2BF /* ReplacementJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A123378D4E002DE2BF /* ReplacementJob.swift */; };
 		1F1628A423378D7C002DE2BF /* HttpServerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */; };
+		1F5AD060233A1D3D0071E01E /* PortSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */; };
 		1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */; };
 		1FE86220228D7197003EA159 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF8B227319DE008B37F4 /* AccessibilityIdentifiers.swift */; };
 		70D2FF1B2271F9C7008B37F4 /* TWUITests.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D2FF192271F9C7008B37F4 /* TWUITests.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -78,6 +79,7 @@
 		1F16289F23378D0B002DE2BF /* PortSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortSettings.swift; sourceTree = "<group>"; };
 		1F1628A123378D4E002DE2BF /* ReplacementJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementJob.swift; sourceTree = "<group>"; };
 		1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServerProtocol.swift; sourceTree = "<group>"; };
+		1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortSettingsTests.swift; sourceTree = "<group>"; };
 		1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
 		70D2FF162271F9C7008B37F4 /* TWUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TWUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D2FF192271F9C7008B37F4 /* TWUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TWUITests.h; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 			children = (
 				03A1579F22FD66B700A60090 /* Info.plist */,
 				03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */,
+				1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */,
 			);
 			path = TWUITestsTests;
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03A157A722FD952C00A60090 /* RegexJSONModifierTests.swift in Sources */,
+				1F5AD060233A1D3D0071E01E /* PortSettingsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		03A157A022FD66B700A60090 /* TWUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70D2FF162271F9C7008B37F4 /* TWUITests.framework */; };
 		03A157A722FD952C00A60090 /* RegexJSONModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */; };
 		03A157A922FD954E00A60090 /* RegexJSONModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A157A822FD954E00A60090 /* RegexJSONModifier.swift */; };
+		1F1628A023378D0B002DE2BF /* PortSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16289F23378D0B002DE2BF /* PortSettings.swift */; };
+		1F1628A223378D4E002DE2BF /* ReplacementJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A123378D4E002DE2BF /* ReplacementJob.swift */; };
+		1F1628A423378D7C002DE2BF /* HttpServerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */; };
 		1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */; };
 		1FE86220228D7197003EA159 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF8B227319DE008B37F4 /* AccessibilityIdentifiers.swift */; };
 		70D2FF1B2271F9C7008B37F4 /* TWUITests.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D2FF192271F9C7008B37F4 /* TWUITests.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -20,7 +23,7 @@
 		70D2FF322271F9D4008B37F4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 70D2FF302271F9D4008B37F4 /* LaunchScreen.storyboard */; };
 		70D2FF472271FA6A008B37F4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70D2FF462271FA6A008B37F4 /* XCTest.framework */; };
 		70D2FF4A22720243008B37F4 /* Swifter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70D2FF4922720243008B37F4 /* Swifter.framework */; };
-		70D2FF4D227202C6008B37F4 /* HTTPDynamicStubbs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF4C227202C6008B37F4 /* HTTPDynamicStubbs.swift */; };
+		70D2FF4D227202C6008B37F4 /* HTTPDynamicStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF4C227202C6008B37F4 /* HTTPDynamicStubs.swift */; };
 		70D2FF4F227202D7008B37F4 /* HTTPStubsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF4E227202D7008B37F4 /* HTTPStubsList.swift */; };
 		70D2FF5222720343008B37F4 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF5122720343008B37F4 /* Configuration.swift */; };
 		70D2FF5422720372008B37F4 /* APIStubInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF5322720372008B37F4 /* APIStubInfo.swift */; };
@@ -72,6 +75,9 @@
 		03A1579F22FD66B700A60090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexJSONModifierTests.swift; sourceTree = "<group>"; };
 		03A157A822FD954E00A60090 /* RegexJSONModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexJSONModifier.swift; sourceTree = "<group>"; };
+		1F16289F23378D0B002DE2BF /* PortSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortSettings.swift; sourceTree = "<group>"; };
+		1F1628A123378D4E002DE2BF /* ReplacementJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementJob.swift; sourceTree = "<group>"; };
+		1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServerProtocol.swift; sourceTree = "<group>"; };
 		1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
 		70D2FF162271F9C7008B37F4 /* TWUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TWUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D2FF192271F9C7008B37F4 /* TWUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TWUITests.h; sourceTree = "<group>"; };
@@ -87,7 +93,7 @@
 		70D2FF3E2271F9D5008B37F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		70D2FF462271FA6A008B37F4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		70D2FF4922720243008B37F4 /* Swifter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Swifter.framework; path = Carthage/Build/iOS/Swifter.framework; sourceTree = "<group>"; };
-		70D2FF4C227202C6008B37F4 /* HTTPDynamicStubbs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDynamicStubbs.swift; sourceTree = "<group>"; };
+		70D2FF4C227202C6008B37F4 /* HTTPDynamicStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDynamicStubs.swift; sourceTree = "<group>"; };
 		70D2FF4E227202D7008B37F4 /* HTTPStubsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStubsList.swift; sourceTree = "<group>"; };
 		70D2FF5122720343008B37F4 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		70D2FF5322720372008B37F4 /* APIStubInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIStubInfo.swift; sourceTree = "<group>"; };
@@ -236,9 +242,12 @@
 		70D2FF4B227202AC008B37F4 /* APIStubs */ = {
 			isa = PBXGroup;
 			children = (
-				70D2FF4C227202C6008B37F4 /* HTTPDynamicStubbs.swift */,
+				70D2FF4C227202C6008B37F4 /* HTTPDynamicStubs.swift */,
 				70D2FF4E227202D7008B37F4 /* HTTPStubsList.swift */,
+				1F16289F23378D0B002DE2BF /* PortSettings.swift */,
 				03A157A822FD954E00A60090 /* RegexJSONModifier.swift */,
+				1F1628A123378D4E002DE2BF /* ReplacementJob.swift */,
+				1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */,
 			);
 			path = APIStubs;
 			sourceTree = "<group>";
@@ -537,8 +546,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F1628A223378D4E002DE2BF /* ReplacementJob.swift in Sources */,
 				70D2FF5222720343008B37F4 /* Configuration.swift in Sources */,
-				70D2FF4D227202C6008B37F4 /* HTTPDynamicStubbs.swift in Sources */,
+				70D2FF4D227202C6008B37F4 /* HTTPDynamicStubs.swift in Sources */,
+				1F1628A023378D0B002DE2BF /* PortSettings.swift in Sources */,
 				70D2FF642272EB39008B37F4 /* UITestApplication+When.swift in Sources */,
 				70D2FF572272E9C4008B37F4 /* PageObjectModel.swift in Sources */,
 				70D2FF622272EAFB008B37F4 /* UITestCase+Given.swift in Sources */,
@@ -553,6 +564,7 @@
 				70D2FF5B2272EA63008B37F4 /* UITestBase.swift in Sources */,
 				70D2FF6B2272EC24008B37F4 /* XCUIElementQuery+Extension.swift in Sources */,
 				70D2FF592272E9F9008B37F4 /* UITestCase.swift in Sources */,
+				1F1628A423378D7C002DE2BF /* HttpServerProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TWUITests/APIStubs/HTTPDynamicStubs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubs.swift
@@ -35,15 +35,14 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         initialStubs: [APIStubInfo] = HTTPDynamicStubsList().initialStubs,
         regexModifier: RegexJSONModifier = RegexJSONModifier(),
         appID: String,
-        port: UInt16,
-        portRange: ClosedRange<UInt16>?,
+        port: APIConfiguration.PortType,
         maxPortRetries: Int = 5
     ) {
         self.fileManager = fileManager
         self.server = server
         self.appID = appID
         self.regexModifier = regexModifier
-        self.portSettings = PortSettings(portRange: portRange, port: port, maxRetriesCount: maxPortRetries)
+        self.portSettings = PortSettings(port: port, maxRetriesCount: maxPortRetries)
         setup(initialStubs: initialStubs)
     }
 
@@ -53,13 +52,11 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         } catch let error as SocketError {
             guard
                 case .bindFailed = error,
-                portSettings.canRetry,
-                let newPort = portSettings.randomPort
+                portSettings.canRetry
             else {
                 showError("Failed to start local server after \(portSettings.maxRetriesCount) retries. \(error.localizedDescription)")
             }
-            portSettings.retried()
-            portSettings.port = newPort
+            portSettings.retry()
             start()
         } catch {
             showError("Failed to start local server \(error.localizedDescription)")

--- a/TWUITests/APIStubs/HTTPDynamicStubs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubs.swift
@@ -51,7 +51,11 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         do {
             try server.start(portSettings.port)
         } catch let error as SocketError {
-            guard portSettings.canRetry, let newPort = portSettings.randomPort else {
+            guard
+                case .bindFailed = error,
+                portSettings.canRetry,
+                let newPort = portSettings.randomPort
+            else {
                 showError("Failed to start local server after \(portSettings.maxRetriesCount) retries. \(error.localizedDescription)")
             }
             portSettings.retried()

--- a/TWUITests/APIStubs/HTTPDynamicStubs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubs.swift
@@ -51,7 +51,7 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         do {
             try server.start(portSettings.port)
         } catch let error as SocketError {
-            guard portSettings.canRetry, let newPort = portSettings.portRange?.randomElement() else {
+            guard portSettings.canRetry, let newPort = portSettings.randomPort else {
                 showError("Failed to start local server after \(portSettings.maxRetriesCount) retries. \(error.localizedDescription)")
             }
             portSettings.retried()

--- a/TWUITests/APIStubs/HttpServerProtocol.swift
+++ b/TWUITests/APIStubs/HttpServerProtocol.swift
@@ -1,0 +1,18 @@
+import Swifter
+
+protocol HttpServerProtocol: AnyObject {
+    var DELETE: Swifter.HttpServer.MethodRoute { get set }
+    var POST: Swifter.HttpServer.MethodRoute { get set }
+    var GET: Swifter.HttpServer.MethodRoute { get set }
+    var PUT: Swifter.HttpServer.MethodRoute { get set }
+    func start(_ port: in_port_t, forceIPv4: Bool, priority: DispatchQoS.QoSClass) throws
+    func stop()
+}
+
+extension HttpServerProtocol {
+    func start(_ port: in_port_t = 8080, forceIPv4: Bool = false, priority: DispatchQoS.QoSClass = DispatchQoS.QoSClass.background) throws {
+        try start(port, forceIPv4: forceIPv4, priority: priority)
+    }
+}
+
+extension HttpServer: HttpServerProtocol {}

--- a/TWUITests/APIStubs/PortSettings.swift
+++ b/TWUITests/APIStubs/PortSettings.swift
@@ -1,24 +1,35 @@
 struct PortSettings {
-    var port: UInt16
     let maxRetriesCount: Int
-    private let portRange: ClosedRange<UInt16>?
+    private(set) var port: UInt16
+    private let portType: APIConfiguration.PortType
     private var retriesCount: Int = 0
 
-    init(portRange: ClosedRange<UInt16>?, port: UInt16, maxRetriesCount: Int) {
-        self.portRange = portRange
-        self.port = port
+    init(port: APIConfiguration.PortType, maxRetriesCount: Int) {
+        self.portType = port
         self.maxRetriesCount = maxRetriesCount
+        switch portType {
+        case .fixed(let port):
+           self.port = port
+        case .range(let portRange):
+            self.port = portRange.first!
+        }
     }
 
     var canRetry: Bool {
         return retriesCount < maxRetriesCount
     }
 
-    var randomPort: UInt16? {
-        return portRange?.randomElement()
+    mutating func retry() {
+        port = generatedPort
+        retriesCount += 1
     }
 
-    mutating func retried() {
-        retriesCount += 1
+    private var generatedPort: UInt16 {
+        switch portType {
+        case .range(let portRange):
+            return portRange.randomElement()!
+        case .fixed(let port):
+            return port
+        }
     }
 }

--- a/TWUITests/APIStubs/PortSettings.swift
+++ b/TWUITests/APIStubs/PortSettings.swift
@@ -14,6 +14,10 @@ struct PortSettings {
         return retriesCount < maxRetriesCount
     }
 
+    var randomPort: UInt16? {
+        return portRange?.randomElement()
+    }
+
     mutating func retried() {
         retriesCount += 1
     }

--- a/TWUITests/APIStubs/PortSettings.swift
+++ b/TWUITests/APIStubs/PortSettings.swift
@@ -1,0 +1,20 @@
+struct PortSettings {
+    let portRange: ClosedRange<UInt16>?
+    let maxRetriesCount: Int
+    var port: UInt16
+    private var retriesCount: Int = 0
+
+    init(portRange: ClosedRange<UInt16>?, port: UInt16, maxRetriesCount: Int) {
+        self.portRange = portRange
+        self.port = port
+        self.maxRetriesCount = maxRetriesCount
+    }
+
+    var canRetry: Bool {
+        return retriesCount < maxRetriesCount
+    }
+
+    mutating func retried() {
+        retriesCount += 1
+    }
+}

--- a/TWUITests/APIStubs/PortSettings.swift
+++ b/TWUITests/APIStubs/PortSettings.swift
@@ -1,7 +1,7 @@
 struct PortSettings {
-    let portRange: ClosedRange<UInt16>?
-    let maxRetriesCount: Int
     var port: UInt16
+    let maxRetriesCount: Int
+    private let portRange: ClosedRange<UInt16>?
     private var retriesCount: Int = 0
 
     init(portRange: ClosedRange<UInt16>?, port: UInt16, maxRetriesCount: Int) {

--- a/TWUITests/APIStubs/ReplacementJob.swift
+++ b/TWUITests/APIStubs/ReplacementJob.swift
@@ -1,0 +1,4 @@
+struct ReplacementJob {
+    let modification: RegexJSONModifier.Modification
+    let stub: APIStubInfo
+}

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -71,7 +71,7 @@ extension UITestApplication: XCUIApplicationStarter {
     }
 
     private func serverStart(with apiConfiguration: APIConfiguration) {
-        server = HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port, portRange: apiConfiguration.portRange)
+        server = HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port)
         server?.start()
         apiConfiguration.apiStubs.forEach {
             server?.update(with: $0)

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -71,7 +71,7 @@ extension UITestApplication: XCUIApplicationStarter {
     }
 
     private func serverStart(with apiConfiguration: APIConfiguration) {
-        server = HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port)
+        server = HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port, portRange: apiConfiguration.portRange)
         server?.start()
         apiConfiguration.apiStubs.forEach {
             server?.update(with: $0)

--- a/TWUITests/Configuration/APIConfiguration.swift
+++ b/TWUITests/Configuration/APIConfiguration.swift
@@ -17,15 +17,18 @@ import Foundation
 public struct APIConfiguration {
     public let appID: String
     public var port: UInt16
+    public var portRange: ClosedRange<UInt16>
     public var apiStubs: [APIStubInfo]
 
     public init(
         port: UInt16,
+        portRange: ClosedRange<UInt16>,
         apiStubs: [APIStubInfo],
         appID: String = ""
     ) {
         self.appID = appID
         self.port = port
+        self.portRange = portRange
         self.apiStubs = apiStubs
     }
 }

--- a/TWUITests/Configuration/APIConfiguration.swift
+++ b/TWUITests/Configuration/APIConfiguration.swift
@@ -15,20 +15,31 @@
 import Foundation
 
 public struct APIConfiguration {
+    public enum PortType {
+        case fixed(UInt16)
+        case range(ClosedRange<UInt16>)
+    }
     public let appID: String
-    public var port: UInt16
-    public var portRange: ClosedRange<UInt16>?
+    public var port: PortType
     public var apiStubs: [APIStubInfo]
 
     public init(
         port: UInt16,
-        portRange: ClosedRange<UInt16>? = nil,
         apiStubs: [APIStubInfo],
         appID: String = ""
     ) {
         self.appID = appID
-        self.port = port
-        self.portRange = portRange
+        self.port = .fixed(port)
+        self.apiStubs = apiStubs
+    }
+
+    public init(
+        portRange: ClosedRange<UInt16>,
+        apiStubs: [APIStubInfo],
+        appID: String = ""
+    ) {
+        self.appID = appID
+        self.port = .range(portRange)
         self.apiStubs = apiStubs
     }
 }

--- a/TWUITests/Configuration/APIConfiguration.swift
+++ b/TWUITests/Configuration/APIConfiguration.swift
@@ -17,12 +17,12 @@ import Foundation
 public struct APIConfiguration {
     public let appID: String
     public var port: UInt16
-    public var portRange: ClosedRange<UInt16>
+    public var portRange: ClosedRange<UInt16>?
     public var apiStubs: [APIStubInfo]
 
     public init(
         port: UInt16,
-        portRange: ClosedRange<UInt16>,
+        portRange: ClosedRange<UInt16>? = nil,
         apiStubs: [APIStubInfo],
         appID: String = ""
     ) {

--- a/TWUITestsTests/PortSettingsTests.swift
+++ b/TWUITestsTests/PortSettingsTests.swift
@@ -1,0 +1,42 @@
+//  Copyright 2019 Hotspring Ventures Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import TWUITests
+
+final class PortSettingsTests: XCTestCase {
+    func testFixedPortRetry() {
+        var sut = PortSettings(port: .fixed(1000), maxRetriesCount: 3)
+        XCTAssertTrue(sut.canRetry)
+        XCTAssertEqual(sut.maxRetriesCount, 3)
+        XCTAssertEqual(sut.port, 1000)
+        sut.retry()
+        sut.retry()
+        sut.retry()
+        XCTAssertFalse(sut.canRetry)
+    }
+
+    func testFixedPortRangeRetry() {
+        var sut = PortSettings(port: .range(0...10), maxRetriesCount: 3)
+        XCTAssertTrue(sut.canRetry)
+        XCTAssertEqual(sut.maxRetriesCount, 3)
+        XCTAssertTrue((0...10).contains(sut.port))
+        sut.retry()
+        XCTAssertTrue((0...10).contains(sut.port))
+        sut.retry()
+        XCTAssertTrue((0...10).contains(sut.port))
+        sut.retry()
+        XCTAssertFalse(sut.canRetry)
+    }
+}


### PR DESCRIPTION
Introduced config property `portRange` to be able to specify port range. This allows to retry server start if current port is taken.

P.S. was not able to add uTest because it was not possible to initialise`Swifter.HttpServer.MethodRoute`.