### PR TITLE
Added a check for element.isHittable to swipeUp func to ensure…

### DIFF
--- a/TWUITests/Helpers/XCUIElement+Extensions.swift
+++ b/TWUITests/Helpers/XCUIElement+Extensions.swift
@@ -53,7 +53,7 @@ public extension XCUIElement {
      */
     func swipeUp(to element: XCUIElement, maxSwipes: UInt = 5) -> Bool {
         for _ in 0..<maxSwipes {
-            if element.exists {
+            if element.exists && element.isHittable {
                 return true
             } else {
                 swipeUp()


### PR DESCRIPTION
…element is visible.

This should mean that swiping up will continue until the element is visible on screen.