### PR TITLE
Make app.start() public

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "httpswift/swifter" "1.4.6"
+github "httpswift/swifter" "1.4.7"

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -64,8 +64,9 @@ public final class UITestApplication: XCUIApplication {
 }
 
 extension UITestApplication: XCUIApplicationStarter {
+    
     // UI tests must launch the application that they test.
-    func start(using configuration: Configuration) {
+    public func start(using configuration: Configuration) {
         let port = serverStart(with: configuration.apiConfiguration)
         configuration.update(port: port)
         set(configuration: configuration).launch()


### PR DESCRIPTION
I have a test case where I need to restart the app to test if a setting is persisted. For that purpose I need to expose the `start` method of `UITestApplication` so that I can wrap the `restart` function into a `ApplicationStep`

```swift
import TWUITests

final class ApplicationStep: UITestBase, Step {
    
    func restart(using configuration: Configuration) -> UITestApplication {
        resetLaunchEnvironment()        
        app.start(using: configuration)
        return app
    }
    
    // MARK: Private helpers
    
    private func resetLaunchEnvironment() {
        var environment = app.launchEnvironment
        for key in ConfigurationKeys.allCases {
            environment[key.rawValue] = nil
        }
        
        app.launchEnvironment = environment
    }
}

// MARK: - Add to Application

extension UITestApplication {
    var applicationStep: ApplicationStep {
        return ApplicationStep(app: self)
    }
}
```

with this setup, I can write a test case like the following:

```swift
start(using: ConfigurationSetting.WithTask())
    .homeStep
        .saveSettings()
    .applicationStep
        .restart(using: ConfigurationSetting.NoReset())
    .homeStep
        .verifySettingsExist()

```