### PR TITLE
Added ability to inject custom API mocks on app launch

### DIFF
--- a/Example/APIProvider.swift
+++ b/Example/APIProvider.swift
@@ -1,0 +1,40 @@
+//  Copyright 2019 Hotspring Ventures Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+final class APIProvider {
+    static func fetchAuthenticationStatus(completion: @escaping (Data?) -> Void) {
+        let baseUrl: String
+        if
+            ProcessInfo.processInfo.environment[ConfigurationKeys.isUITest] == "true",
+            let port = ProcessInfo.processInfo.environment[ConfigurationKeys.serverPort] {
+            baseUrl = "http://localhost:\(port)"
+        } else {
+            baseUrl = "https://run.mocky.io"
+        }
+
+        let url = URL(string: "\(baseUrl)/v3/a34970a7-b5b4-4c7d-8b38-e74efb3ef895")!
+        print("Fetching from: \(url)")
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                preconditionFailure(error.localizedDescription)
+            }
+
+            DispatchQueue.main.async {
+                completion(data)
+            }
+        }.resume()
+    }
+}

--- a/Example/APIStubs/stub.authentication.json
+++ b/Example/APIStubs/stub.authentication.json
@@ -1,0 +1,3 @@
+{
+  "result": "UNKNOWN"
+}

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pJm-Tr-KYn">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pJm-Tr-KYn">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,39 +17,45 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="4tY-TJ-Vhu">
-                                <rect key="frame" x="107" y="288" width="200" height="30"/>
+                                <rect key="frame" x="107" y="288" width="200" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="fNM-TE-08b"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Vjh-Y4-uod">
-                                <rect key="frame" x="107" y="333" width="200" height="30"/>
+                                <rect key="frame" x="107" y="337" width="200" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="aai-MW-1NL"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fQf-3y-86x">
-                                <rect key="frame" x="188" y="393" width="38" height="30"/>
+                                <rect key="frame" x="188" y="401" width="38" height="30"/>
                                 <state key="normal" title="Login"/>
                                 <connections>
                                     <action selector="loginButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2m8-1R-qn2"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NUL-eW-vHm">
+                                <rect key="frame" x="186" y="217" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="fQf-3y-86x" firstAttribute="top" secondItem="Vjh-Y4-uod" secondAttribute="bottom" constant="30" id="4KU-cE-u2E"/>
+                            <constraint firstItem="4tY-TJ-Vhu" firstAttribute="top" secondItem="NUL-eW-vHm" secondAttribute="bottom" constant="50" id="5Gu-6V-nYL"/>
                             <constraint firstItem="Vjh-Y4-uod" firstAttribute="leading" secondItem="4tY-TJ-Vhu" secondAttribute="leading" id="Ar4-Uy-hn1"/>
                             <constraint firstItem="Vjh-Y4-uod" firstAttribute="top" secondItem="4tY-TJ-Vhu" secondAttribute="bottom" constant="15" id="O45-sL-Gwh"/>
                             <constraint firstItem="4tY-TJ-Vhu" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="200" id="PAs-IO-uig"/>
                             <constraint firstItem="4tY-TJ-Vhu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="aJc-GD-nA9"/>
                             <constraint firstItem="Vjh-Y4-uod" firstAttribute="trailing" secondItem="4tY-TJ-Vhu" secondAttribute="trailing" id="fF0-yH-nX3"/>
+                            <constraint firstItem="NUL-eW-vHm" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="hgw-1h-Kav"/>
                             <constraint firstItem="fQf-3y-86x" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="k0e-9h-Jkp"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -60,6 +64,7 @@
                     <connections>
                         <outlet property="loginButton" destination="fQf-3y-86x" id="23c-PT-Npv"/>
                         <outlet property="passwordTextField" destination="Vjh-Y4-uod" id="0hG-R6-zVv"/>
+                        <outlet property="statusLabel" destination="NUL-eW-vHm" id="dQY-PW-nYY"/>
                         <outlet property="usernameTextField" destination="4tY-TJ-Vhu" id="NI7-lQ-9TV"/>
                         <segue destination="sVv-d5-2oA" kind="show" identifier="showHomeScreen" id="32e-Rl-Duj"/>
                     </connections>
@@ -82,14 +87,26 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VEH-AF-8ZA">
+                                <rect key="frame" x="156" y="498.5" width="102" height="30"/>
+                                <state key="normal" title="Fetch from API"/>
+                                <connections>
+                                    <action selector="fetchAction:" destination="sVv-d5-2oA" eventType="touchUpInside" id="inO-Tl-Vw8"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="9Lg-nq-spu" firstAttribute="centerX" secondItem="yrm-WE-wpQ" secondAttribute="centerX" id="BXt-4r-egc"/>
                             <constraint firstItem="9Lg-nq-spu" firstAttribute="centerY" secondItem="yrm-WE-wpQ" secondAttribute="centerY" id="Rj5-wX-c4Q"/>
+                            <constraint firstItem="VEH-AF-8ZA" firstAttribute="centerX" secondItem="yrm-WE-wpQ" secondAttribute="centerX" id="cxe-xc-MDu"/>
+                            <constraint firstItem="VEH-AF-8ZA" firstAttribute="top" secondItem="9Lg-nq-spu" secondAttribute="bottom" constant="40" id="m9e-3e-rr1"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="rSJ-wh-0jL"/>
                     </view>
+                    <connections>
+                        <outlet property="fetchButton" destination="VEH-AF-8ZA" id="dhg-ny-Yc8"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Rqs-TQ-EgE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Example/HomeViewController.swift
+++ b/Example/HomeViewController.swift
@@ -15,9 +15,22 @@
 import UIKit
 
 class HomeViewController: UIViewController {
+    @IBOutlet weak var fetchButton: UIButton!
+    @IBAction func fetchAction(_ sender: Any) {
+        APIProvider.fetchAuthenticationStatus { data in
+            if
+                let json = try? JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any],
+                let result = json["result"] as? String {
 
+                let alert = UIAlertController(title: "Result", message: result, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "Close", style: .cancel, handler: nil))
+                self.present(alert, animated: true)
+            }
+        }
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         view.accessibilityIdentifier = Accessibility.Home.mainView
+        fetchButton.accessibilityIdentifier = Accessibility.Home.Button.fetch
     }
 }

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -41,5 +41,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Example/copy-api-mocks.py
+++ b/Example/copy-api-mocks.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Hotspring Ventures Ltd.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import shutil
+import subprocess
+
+DEVICE_ID = sys.argv[1]
+LIBRARY_DIR = sys.argv[2]
+APP_ID = sys.argv[3]
+print('Device id:', DEVICE_ID)
+print('Library dir:', LIBRARY_DIR)
+print('App ID:', APP_ID)
+CACHES_DIR = LIBRARY_DIR + "/Developer/CoreSimulator/Devices/" + DEVICE_ID + "/data/Library/Caches/ApiStubs/" + APP_ID + "/"
+print('CACHES_DIR:', CACHES_DIR)
+LOCAL_CACHE_DIR = os.environ['PROJECT_DIR'] + "/" + os.environ['TARGET_NAME'] + "/ApiStubs/"
+print('LOCAL_CACHE_DIR:', LOCAL_CACHE_DIR)
+
+DIRECTORY_EXISTS = os.path.isdir(CACHES_DIR)
+if os.path.isdir(LOCAL_CACHE_DIR):
+    print('Using local cached API stubs')
+    if DIRECTORY_EXISTS:
+        print('Found device caches directory, removing it...')
+        shutil.rmtree(CACHES_DIR)
+    print('Copying local cache to device')
+    shutil.copytree(LOCAL_CACHE_DIR, CACHES_DIR)
+    exit(0)

--- a/ExampleUITests/Home/HomePage.swift
+++ b/ExampleUITests/Home/HomePage.swift
@@ -19,6 +19,10 @@ final class HomePage: UITestBase, Page {
     var mainView: XCUIElement {
         return app.otherElements[Accessibility.Home.mainView]
     }
+
+    var buttonFetch: XCUIElement {
+        return app.buttons[Accessibility.Home.Button.fetch]
+    }
 }
 
 // MARK: - Add to Application

--- a/ExampleUITests/Home/HomeStep.swift
+++ b/ExampleUITests/Home/HomeStep.swift
@@ -17,13 +17,32 @@ import XCTest
 
 final class HomeStep: UITestBase, Step {
     lazy var homePage = HomePage(app: app)
+
+    func tapButtonFetch() -> UITestApplication {
+        homePage.buttonFetch.tap()
+        return app
+    }
 }
 
 // MARK: - Validation
 
 extension HomeStep {
-    func homeScreenIsVisible() {
+    @discardableResult
+    func homeScreenIsVisible() -> UITestApplication {
         homePage.mainView.existsAfterDelay()
+        return app
+    }
+
+    @discardableResult
+    func alertIsVisible() -> UITestApplication {
+        let result = app.alerts.wait(forExpectationWithFormat: "count == 1")
+        XCTAssertEqual(result, .completed, "Error alert is not visible")
+        return app
+    }
+
+    func alertContains(text: String) {
+        let predicate = NSPredicate(format: "label CONTAINS %@", text)
+        XCTAssert(app.alerts.firstMatch.staticTexts.matching(predicate).firstMatch.exists)
     }
 }
 

--- a/ExampleUITests/Home/HomeUITests.swift
+++ b/ExampleUITests/Home/HomeUITests.swift
@@ -16,5 +16,18 @@ import Foundation
 import TWUITests
 
 final class HomeTests: UITestCase {
-
+    func testAPIResponse() {
+        start(using: Configuration().isUser("hello@domain.com", password: "password")) { app in
+            app.replaceValues(
+                of: [
+                    "result": "AUTHENTICATED"
+                ],
+                in: Stub.Authentication.success
+            )
+        }
+        .homeStep.homeScreenIsVisible()
+        .homeStep.tapButtonFetch()
+        .homeStep.alertIsVisible()
+        .homeStep.alertContains(text: "AUTHENTICATED")
+    }
 }

--- a/ExampleUITests/Login/LoginPage.swift
+++ b/ExampleUITests/Login/LoginPage.swift
@@ -31,6 +31,10 @@ final class LoginPage: UITestBase, Page {
     var buttonLogin: XCUIElement {
         return app.buttons[Accessibility.Login.Button.login]
     }
+
+    var labelAuthStatus: XCUIElement {
+        return app.staticTexts[Accessibility.Login.Label.authStatus]
+    }
 }
 
 // MARK: - Add to Application

--- a/ExampleUITests/Login/LoginStep.swift
+++ b/ExampleUITests/Login/LoginStep.swift
@@ -53,6 +53,16 @@ extension LoginStep {
     func errorAlertIsVisible() {
         XCTAssertEqual(app.alerts.count, 1, "Error alert is not visible")
     }
+
+    @discardableResult
+    func authenticationStatusIsVisible() -> UITestApplication {
+        loginPage.labelAuthStatus.existsAfterDelay()
+        return app
+    }
+
+    func authenticationStatusIs(equal text: String) {
+        XCTAssertEqual(loginPage.labelAuthStatus.label, text)
+    }
 }
 
 // MARK: - Add to Application

--- a/ExampleUITests/Login/LoginUITests.swift
+++ b/ExampleUITests/Login/LoginUITests.swift
@@ -39,4 +39,17 @@ final class LoginUITests: UITestCase {
         .loginStep.providesUsername("hello@domain.com", password: "password")
         .homeStep.homeScreenIsVisible()
     }
+
+    func testAPIResponse() {
+        start(using: Configuration()) { app in
+            app.replaceValues(
+                of: [
+                    "result": "NOT_AUTHENTICATED"
+                ],
+                in: Stub.Authentication.success
+            )
+        }
+        .loginStep.authenticationStatusIsVisible()
+        .loginStep.authenticationStatusIs(equal: "NOT_AUTHENTICATED")
+    }
 }

--- a/ExampleUITests/Tests Support/AccessibilityIdentifiers.swift
+++ b/ExampleUITests/Tests Support/AccessibilityIdentifiers.swift
@@ -26,9 +26,17 @@ struct Accessibility {
         struct Button {
             static let login = "login_screen.button.login"
         }
+
+        struct Label {
+            static let authStatus = "login_screen.label.auth_status"
+        }
     }
 
     struct Home {
         static let mainView = "home_screen.main_view"
+
+        struct Button {
+            static let fetch = "home_screen.button.fetch"
+        }
     }
 }

--- a/ExampleUITests/Tests Support/Configuration.swift
+++ b/ExampleUITests/Tests Support/Configuration.swift
@@ -17,8 +17,8 @@ import TWUITests
 final class Configuration: TWUITests.Configuration {
     var apiConfiguration: APIConfiguration = APIConfiguration(
         portRange: 9000...9999,
-        apiStubs: [],   // Add defaults API stubs here
-        appID: ""       // appID is used to specify stubs path
+        apiStubs: [], // Add defaults API stubs here
+        appID: "com.treatwell.Example" // appID is used to specify stubs path
     )
 
     var dictionary: [String: String] = [

--- a/ExampleUITests/Tests Support/ConfigurationKeys.swift
+++ b/ExampleUITests/Tests Support/ConfigurationKeys.swift
@@ -17,4 +17,5 @@ public enum ConfigurationKeys {
     public static let isAnimationsEnabled = "UI_TEST_IS_ANIMATIONS_ENABLED"
     public static let isFirstTimeUser = "UI_TEST_IS_FIRST_TIME_USER"
     public static let isUser = "UI_TEST_IS_USER"
+    public static let serverPort = "UI_TEST_SERVER_PORT"
 }

--- a/ExampleUITests/Tests Support/Stub.swift
+++ b/ExampleUITests/Tests Support/Stub.swift
@@ -16,7 +16,7 @@ import TWUITests
 
 enum Stub {
     enum Authentication {
-        static let success = APIStubInfo(statusCode: 200, url: "/api/authentication", jsonFilename: "authentication", method: .POST)
-        static let failure = APIStubInfo(statusCode: 200, url: "/api/authentication", jsonFilename: "authentication-failed", method: .POST)
+        static let success = APIStubInfo(statusCode: 200, url: "/v3/a34970a7-b5b4-4c7d-8b38-e74efb3ef895", jsonFilename: "stub.authentication", method: .GET)
+        static let failure = APIStubInfo(statusCode: 500, url: "/v3/a34970a7-b5b4-4c7d-8b38-e74efb3ef895", jsonFilename: "stub.authentication", method: .GET)
     }
 }

--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1F5AD060233A1D3D0071E01E /* PortSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */; };
 		1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */; };
 		1FE86220228D7197003EA159 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF8B227319DE008B37F4 /* AccessibilityIdentifiers.swift */; };
+		293F1D19248F815800EC03C4 /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293F1D18248F815800EC03C4 /* APIProvider.swift */; };
 		70D2FF1B2271F9C7008B37F4 /* TWUITests.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D2FF192271F9C7008B37F4 /* TWUITests.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		70D2FF282271F9D4008B37F4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF272271F9D4008B37F4 /* AppDelegate.swift */; };
 		70D2FF2A2271F9D4008B37F4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF292271F9D4008B37F4 /* ViewController.swift */; };
@@ -81,6 +82,7 @@
 		1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServerProtocol.swift; sourceTree = "<group>"; };
 		1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortSettingsTests.swift; sourceTree = "<group>"; };
 		1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
+		293F1D18248F815800EC03C4 /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		70D2FF162271F9C7008B37F4 /* TWUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TWUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D2FF192271F9C7008B37F4 /* TWUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TWUITests.h; sourceTree = "<group>"; };
 		70D2FF1A2271F9C7008B37F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 				70D2FF2E2271F9D4008B37F4 /* Assets.xcassets */,
 				70D2FF302271F9D4008B37F4 /* LaunchScreen.storyboard */,
 				70D2FF332271F9D4008B37F4 /* Info.plist */,
+				293F1D18248F815800EC03C4 /* APIProvider.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 				70D2FF212271F9D4008B37F4 /* Sources */,
 				70D2FF222271F9D4008B37F4 /* Frameworks */,
 				70D2FF232271F9D4008B37F4 /* Resources */,
+				293F1D1B248F8DB000EC03C4 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -514,6 +518,23 @@
 			shellPath = /bin/sh;
 			shellScript = "if [ -x \"$(command -v swiftlint)\" ]; then\n    /usr/local/bin/swiftlint\nelse\n    echo \"Swiftlint not installed, skipping\"\nfi\n";
 		};
+		293F1D1B248F8DB000EC03C4 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/Example/copy-api-mocks.py $TARGET_DEVICE_IDENTIFIER $USER_LIBRARY_DIR $PRODUCT_BUNDLE_IDENTIFIER\n";
+		};
 		70D2FF482271FFAC008B37F4 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -581,6 +602,7 @@
 				70D2FF8C227319DE008B37F4 /* AccessibilityIdentifiers.swift in Sources */,
 				70D2FF282271F9D4008B37F4 /* AppDelegate.swift in Sources */,
 				70D2FF8322731869008B37F4 /* HomeViewController.swift in Sources */,
+				293F1D19248F815800EC03C4 /* APIProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TWUITests/Components/UITestCase.swift
+++ b/TWUITests/Components/UITestCase.swift
@@ -17,6 +17,7 @@ import XCTest
 public protocol ApplicationStarter {
     func start(using configuration: Configuration) -> UITestApplication
     func start(using configuration: Configuration, stub: APIStubInfo?)
+    func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) -> UITestApplication
 }
 
 open class UITestCase: XCTestCase {
@@ -43,11 +44,25 @@ extension UITestCase: ApplicationStarter {
         return app
     }
 
+    @available(*, deprecated, message: "Use start(using:initiationClosure:) instead")
     public func start(using configuration: Configuration, stub: APIStubInfo? = nil) {
-        let app = start(using: configuration)
-        if let stub = stub {
-            app.serverUpdate(with: stub)
+        start(using: configuration) { app in
+            if let stub = stub {
+                app.serverUpdate(with: stub)
+            }
+            self.app = app
         }
-        self.app = app
+    }
+
+    /// Start app using specified configuration
+    /// - Parameters:
+    ///   - configuration: Configuration object
+    ///   - initiationClosure: Initiation closure. It is called right after setting up mock server, before app launch.
+    ///   Use this param if you need to inject custom mocked API responses on app launch
+    /// - Returns: UITestApplication
+    @discardableResult
+    public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)? = nil) -> UITestApplication {
+        app.start(using: configuration, initiationClosure: initiationClosure)
+        return app
     }
 }


### PR DESCRIPTION
In order to use **custom API response mocks** (with special data) we used 
```swift
start(using: AppConfiguration())

app.replaceValues(
    of: [
        "result": "NOT_AUTHENTICATED"
    ],
    in: Stub.Authentication.success
)
```
But API mocked responses were replaced only after next refresh/API call. So as a workaround we had to do additional UI actions like pull to refresh, closing and opening screens again and so on, just to get that API endpoint called again.

This **PR** adds nicer way to do that by introducing `initiationClosure` param to `start(using:)`
So, now there is a way to do:

```swift
start(using: Configuration()) { app in
    app.replaceValues(
        of: [
            "result": "NOT_AUTHENTICATED"
        ],
        in: Stub.Authentication.success
    )
}
.loginStep.authenticationStatusIsVisible()
.loginStep.authenticationStatusIs(equal: "NOT_AUTHENTICATED")
```

Using this closure we get our custom replaced API mocks right after UI Tests launches the app.

To better illustrate that, I have updated example app with few examples.