### PR TITLE
Support try - catch in tests

### DIFF
--- a/ExampleUITests/Login/LoginUITests.swift
+++ b/ExampleUITests/Login/LoginUITests.swift
@@ -17,31 +17,31 @@ import XCTest
 
 final class LoginUITests: UITestCase {
 
-    func testFirstTimeUserLoginScreenIsVisible() {
-        start(using: Configuration()
+    func testFirstTimeUserLoginScreenIsVisible() throws {
+        try start(with: Configuration()
             .isFirstTimeUser()
         )
         .loginStep.loginScreenIsVisible()
     }
 
-    func testEmptyUsernameOrPasswordShowsAlert() {
-        start(using: Configuration()
+    func testEmptyUsernameOrPasswordShowsAlert() throws {
+        try start(with: Configuration()
             .isFirstTimeUser()
         )
         .loginStep.providesEmptyCredentials()
         .loginStep.errorAlertIsVisible()
     }
 
-    func testThatUserCanLogin() {
-        start(using: Configuration()
+    func testThatUserCanLogin() throws {
+        try start(with: Configuration()
             .isFirstTimeUser()
         )
         .loginStep.providesUsername("hello@domain.com", password: "password")
         .homeStep.homeScreenIsVisible()
     }
 
-    func testAPIResponse() {
-        start(using: Configuration()) { app in
+    func testAPIResponse() throws {
+        try start(with: Configuration()) { app in
             app.replaceValues(
                 of: [
                     "result": "NOT_AUTHENTICATED"

--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -14,8 +14,10 @@
 		1F1628A223378D4E002DE2BF /* ReplacementJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A123378D4E002DE2BF /* ReplacementJob.swift */; };
 		1F1628A423378D7C002DE2BF /* HttpServerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */; };
 		1F5AD060233A1D3D0071E01E /* PortSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */; };
+		1F7F2EA224BDD439003BF22F /* FileManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7F2EA124BDD439003BF22F /* FileManaging.swift */; };
 		1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */; };
 		1FE86220228D7197003EA159 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF8B227319DE008B37F4 /* AccessibilityIdentifiers.swift */; };
+		1FFB048024BDB97D00E518D5 /* HTTPDynamicStubsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFB047F24BDB97D00E518D5 /* HTTPDynamicStubsTests.swift */; };
 		293F1D19248F815800EC03C4 /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293F1D18248F815800EC03C4 /* APIProvider.swift */; };
 		70D2FF1B2271F9C7008B37F4 /* TWUITests.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D2FF192271F9C7008B37F4 /* TWUITests.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		70D2FF282271F9D4008B37F4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2FF272271F9D4008B37F4 /* AppDelegate.swift */; };
@@ -81,7 +83,9 @@
 		1F1628A123378D4E002DE2BF /* ReplacementJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementJob.swift; sourceTree = "<group>"; };
 		1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServerProtocol.swift; sourceTree = "<group>"; };
 		1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortSettingsTests.swift; sourceTree = "<group>"; };
+		1F7F2EA124BDD439003BF22F /* FileManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManaging.swift; sourceTree = "<group>"; };
 		1FBA39AD2293FEEC0034DF26 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
+		1FFB047F24BDB97D00E518D5 /* HTTPDynamicStubsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDynamicStubsTests.swift; sourceTree = "<group>"; };
 		293F1D18248F815800EC03C4 /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		70D2FF162271F9C7008B37F4 /* TWUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TWUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70D2FF192271F9C7008B37F4 /* TWUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TWUITests.h; sourceTree = "<group>"; };
@@ -168,6 +172,7 @@
 				03A1579F22FD66B700A60090 /* Info.plist */,
 				03A157A622FD952C00A60090 /* RegexJSONModifierTests.swift */,
 				1F5AD05F233A1D3D0071E01E /* PortSettingsTests.swift */,
+				1FFB047F24BDB97D00E518D5 /* HTTPDynamicStubsTests.swift */,
 			);
 			path = TWUITestsTests;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 				03A157A822FD954E00A60090 /* RegexJSONModifier.swift */,
 				1F1628A123378D4E002DE2BF /* ReplacementJob.swift */,
 				1F1628A323378D7C002DE2BF /* HttpServerProtocol.swift */,
+				1F7F2EA124BDD439003BF22F /* FileManaging.swift */,
 			);
 			path = APIStubs;
 			sourceTree = "<group>";
@@ -564,6 +570,7 @@
 			files = (
 				03A157A722FD952C00A60090 /* RegexJSONModifierTests.swift in Sources */,
 				1F5AD060233A1D3D0071E01E /* PortSettingsTests.swift in Sources */,
+				1FFB048024BDB97D00E518D5 /* HTTPDynamicStubsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -586,6 +593,7 @@
 				70D2FF4F227202D7008B37F4 /* HTTPStubsList.swift in Sources */,
 				70D2FF672272EBF4008B37F4 /* XCUIElement+Extensions.swift in Sources */,
 				1FBA39AE2293FEEC0034DF26 /* APIConfiguration.swift in Sources */,
+				1F7F2EA224BDD439003BF22F /* FileManaging.swift in Sources */,
 				70D2FF5B2272EA63008B37F4 /* UITestBase.swift in Sources */,
 				70D2FF6B2272EC24008B37F4 /* XCUIElementQuery+Extension.swift in Sources */,
 				70D2FF592272E9F9008B37F4 /* UITestCase.swift in Sources */,
@@ -664,6 +672,10 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = X5394XCRFK;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TWUITestsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -683,6 +695,10 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = X5394XCRFK;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TWUITestsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TWUITests/APIStubs/FileManaging.swift
+++ b/TWUITests/APIStubs/FileManaging.swift
@@ -13,21 +13,11 @@
 //  limitations under the License.
 
 import Foundation
-import TWUITests
 
-final class HomeTests: UITestCase {
-    func testAPIResponse() throws {
-        try start(with: Configuration().isUser("hello@domain.com", password: "password")) { app in
-            app.replaceValues(
-                of: [
-                    "result": "AUTHENTICATED"
-                ],
-                in: Stub.Authentication.success
-            )
-        }
-        .homeStep.homeScreenIsVisible()
-        .homeStep.tapButtonFetch()
-        .homeStep.alertIsVisible()
-        .homeStep.alertContains(text: "AUTHENTICATED")
-    }
+protocol FileManaging {
+    func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]?) throws
+    func fileExists(atPath path: String) -> Bool
+    func contents(atPath path: String) -> Data?
 }
+
+extension FileManager: FileManaging {}

--- a/TWUITests/APIStubs/HttpServerProtocol.swift
+++ b/TWUITests/APIStubs/HttpServerProtocol.swift
@@ -1,10 +1,10 @@
 import Swifter
 
 protocol HttpServerProtocol: AnyObject {
-    var DELETE: Swifter.HttpServer.MethodRoute { get set }
-    var POST: Swifter.HttpServer.MethodRoute { get set }
-    var GET: Swifter.HttpServer.MethodRoute { get set }
-    var PUT: Swifter.HttpServer.MethodRoute { get set }
+    func methodDELETE(path: String, response: ((HttpRequest) -> HttpResponse)?)
+    func methodPOST(path: String, response: ((HttpRequest) -> HttpResponse)?)
+    func methodGET(path: String, response: ((HttpRequest) -> HttpResponse)?)
+    func methodPUT(path: String, response: ((HttpRequest) -> HttpResponse)?)
     func start(_ port: in_port_t, forceIPv4: Bool, priority: DispatchQoS.QoSClass) throws
     func stop()
 }
@@ -15,4 +15,20 @@ extension HttpServerProtocol {
     }
 }
 
-extension HttpServer: HttpServerProtocol {}
+extension HttpServer: HttpServerProtocol {
+    func methodDELETE(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        DELETE[path] = response
+    }
+
+    func methodPOST(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        POST[path] = response
+    }
+
+    func methodGET(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        GET[path] = response
+    }
+
+    func methodPUT(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        PUT[path] = response
+    }
+}

--- a/TWUITests/APIStubs/PortSettings.swift
+++ b/TWUITests/APIStubs/PortSettings.swift
@@ -1,4 +1,7 @@
 struct PortSettings {
+    enum Error: Swift.Error {
+        case failedToGeneratePort
+    }
     let maxRetriesCount: Int
     private(set) var port: UInt16
     private let portType: APIConfiguration.PortType
@@ -19,15 +22,18 @@ struct PortSettings {
         return retriesCount < maxRetriesCount
     }
 
-    mutating func retry() {
-        port = generatedPort
+    mutating func retry() throws {
         retriesCount += 1
+        port = try generatedPort()
     }
 
-    private var generatedPort: UInt16 {
+    private func generatedPort() throws -> UInt16 {
         switch portType {
         case .range(let portRange):
-            return portRange.randomElement()!
+            guard let port = portRange.randomElement() else {
+                throw Error.failedToGeneratePort
+            }
+            return port
         case .fixed(let port):
             return port
         }

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -16,6 +16,16 @@ import XCTest
 
 protocol XCUIApplicationStarter {
     func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?)
+    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws
+}
+
+extension XCUIApplicationStarter {
+    func start(using configuration: Configuration) {
+        start(using: configuration, initiationClosure: nil)
+    }
+    func start(with configuration: Configuration) throws {
+        try start(with: configuration, initiationClosure: nil)
+    }
 }
 
 public final class UITestApplication: XCUIApplication {
@@ -64,9 +74,18 @@ public final class UITestApplication: XCUIApplication {
 }
 
 extension UITestApplication: XCUIApplicationStarter {
+    @available(*, deprecated, message: "Use throwable start instead")
+    public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) {
+        guard let port = try? serverStart(with: configuration.apiConfiguration, initiationClosure: initiationClosure) else {
+            preconditionFailure("Failed to start server")
+        }
+        configuration.update(port: port)
+        set(configuration: configuration).launch()
+    }
+
     // UI tests must launch the application that they test.
-    public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)? = nil) {
-        let port = serverStart(with: configuration.apiConfiguration, initiationClosure: initiationClosure)
+    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws {
+        let port = try serverStart(with: configuration.apiConfiguration, initiationClosure: initiationClosure)
         configuration.update(port: port)
         set(configuration: configuration).launch()
     }
@@ -74,11 +93,11 @@ extension UITestApplication: XCUIApplicationStarter {
     private func serverStart(
         with apiConfiguration: APIConfiguration,
         initiationClosure: ((UITestApplication) -> Void)? = nil
-    ) -> UInt16 {
-        let server = HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port)
-        let port = server.start()
-        apiConfiguration.apiStubs.forEach {
-            server.update(with: $0)
+    ) throws -> UInt16 {
+        let server = try HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port)
+        let port = try server.startServer()
+        try apiConfiguration.apiStubs.forEach {
+            try server.update(using: $0)
         }
 
         replacementQueue.forEach(replaceOrQueue)

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -15,11 +15,13 @@
 import XCTest
 
 protocol XCUIApplicationStarter {
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?)
     func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws
 }
 
 extension XCUIApplicationStarter {
+    @available(*, deprecated, message: "Use throwable `start(with:)` instead")
     func start(using configuration: Configuration) {
         start(using: configuration, initiationClosure: nil)
     }
@@ -74,7 +76,7 @@ public final class UITestApplication: XCUIApplication {
 }
 
 extension UITestApplication: XCUIApplicationStarter {
-    @available(*, deprecated, message: "Use throwable start instead")
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) {
         guard let port = try? serverStart(with: configuration.apiConfiguration, initiationClosure: initiationClosure) else {
             preconditionFailure("Failed to start server")

--- a/TWUITests/Components/UITestCase.swift
+++ b/TWUITests/Components/UITestCase.swift
@@ -15,9 +15,21 @@
 import XCTest
 
 public protocol ApplicationStarter {
+    func start(with configuration: Configuration) throws -> UITestApplication
+    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws -> UITestApplication
+
+    @available(*, deprecated, message: "Use throwable start(with:) instead")
     func start(using configuration: Configuration) -> UITestApplication
+    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
     func start(using configuration: Configuration, stub: APIStubInfo?)
+    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
     func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) -> UITestApplication
+}
+
+public extension ApplicationStarter {
+    func start(with configuration: Configuration) throws -> UITestApplication {
+        try start(with: configuration, initiationClosure: nil)
+    }
 }
 
 open class UITestCase: XCTestCase {
@@ -38,13 +50,14 @@ open class UITestCase: XCTestCase {
 }
 
 extension UITestCase: ApplicationStarter {
+    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
     @discardableResult
     public func start(using configuration: Configuration) -> UITestApplication {
         app.start(using: configuration)
         return app
     }
 
-    @available(*, deprecated, message: "Use start(using:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use start(with:initiationClosure:) instead")
     public func start(using configuration: Configuration, stub: APIStubInfo? = nil) {
         start(using: configuration) { app in
             if let stub = stub {
@@ -60,6 +73,13 @@ extension UITestCase: ApplicationStarter {
     ///   - initiationClosure: Initiation closure. It is called right after setting up mock server, before app launch.
     ///   Use this param if you need to inject custom mocked API responses on app launch
     /// - Returns: UITestApplication
+    @discardableResult
+    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws -> UITestApplication {
+        try app.start(with: configuration, initiationClosure: initiationClosure)
+        return app
+    }
+
+    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
     @discardableResult
     public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)? = nil) -> UITestApplication {
         app.start(using: configuration, initiationClosure: initiationClosure)

--- a/TWUITests/Components/UITestCase.swift
+++ b/TWUITests/Components/UITestCase.swift
@@ -18,11 +18,11 @@ public protocol ApplicationStarter {
     func start(with configuration: Configuration) throws -> UITestApplication
     func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws -> UITestApplication
 
-    @available(*, deprecated, message: "Use throwable start(with:) instead")
+    @available(*, deprecated, message: "Use throwable `start(with:)` instead")
     func start(using configuration: Configuration) -> UITestApplication
-    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     func start(using configuration: Configuration, stub: APIStubInfo?)
-    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) -> UITestApplication
 }
 
@@ -50,14 +50,14 @@ open class UITestCase: XCTestCase {
 }
 
 extension UITestCase: ApplicationStarter {
-    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     @discardableResult
     public func start(using configuration: Configuration) -> UITestApplication {
         app.start(using: configuration)
         return app
     }
 
-    @available(*, deprecated, message: "Use start(with:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use throwable`start(with:initiationClosure:)` instead")
     public func start(using configuration: Configuration, stub: APIStubInfo? = nil) {
         start(using: configuration) { app in
             if let stub = stub {
@@ -79,7 +79,7 @@ extension UITestCase: ApplicationStarter {
         return app
     }
 
-    @available(*, deprecated, message: "Use throwable start(with:initiationClosure:) instead")
+    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     @discardableResult
     public func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)? = nil) -> UITestApplication {
         app.start(using: configuration, initiationClosure: initiationClosure)

--- a/TWUITests/Conditions/UITestCase+Given.swift
+++ b/TWUITests/Conditions/UITestCase+Given.swift
@@ -15,8 +15,8 @@
 import XCTest
 
 public extension UITestCase {
-    func given(configuration: Configuration, stub: APIStubInfo? = nil) -> UITestApplication {
-        let app = start(using: configuration)
+    func given(configuration: Configuration, stub: APIStubInfo? = nil) throws -> UITestApplication {
+        let app = try start(with: configuration)
         if let stub = stub {
             app.serverUpdate(with: stub)
         }

--- a/TWUITestsTests/HTTPDynamicStubsTests.swift
+++ b/TWUITestsTests/HTTPDynamicStubsTests.swift
@@ -1,0 +1,161 @@
+//  Copyright 2019 Hotspring Ventures Ltd.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+import Swifter
+@testable import TWUITests
+
+final class HTTPDynamicStubsTests: XCTestCase {
+    func testStartServer_startAndStop() throws {
+        // GIVEN: server is initialised with empty stubs list
+        let (fileManager, server) = makeTestObjects()
+        let sut = try makeSUT(
+            fileManager: fileManager,
+            server: server
+        )
+
+        // WHEN: server is started
+        XCTAssertNoThrow(try sut.startServer())
+        XCTAssertTrue(server.startCalled)
+        XCTAssertNil(fileManager.contentsData)
+
+        // AND: server is stopped
+        sut.stop()
+
+        // THEN: server should be stopped
+        XCTAssertTrue(server.stopCalled)
+    }
+
+    func testStartServer_startWithStub() throws {
+        // GIVEN: server is initialised with 1 stub (DELETE method) in stubs list
+        let (fileManager, server) = makeTestObjects()
+        fileManager.contentsData = String(#"{"status": "ok"}"#).data(using: .utf8)
+        let sut = try makeSUT(
+            fileManager: fileManager,
+            server: server,
+            stubs: [APIStubInfo(statusCode: 200, url: "", jsonFilename: "", method: .DELETE)]
+        )
+
+        // WHEN: server is started
+        XCTAssertNoThrow(try sut.startServer())
+        XCTAssertTrue(server.startCalled)
+
+        // THEN: stub should be successfully registered to server
+        XCTAssertTrue(fileManager.fileExistsCalled)
+        XCTAssertTrue(fileManager.contentsCalled)
+        XCTAssertTrue(server.methodDELETECalled)
+    }
+
+    func testStartServer_starAndUpdateStub() throws {
+        // GIVEN: server is started with empty stubs list
+        let (fileManager, server) = makeTestObjects()
+        let sut = try makeSUT(fileManager: fileManager, server: server)
+        XCTAssertNoThrow(try sut.startServer())
+        XCTAssertFalse(fileManager.fileExistsCalled)
+        XCTAssertFalse(fileManager.contentsCalled)
+        XCTAssertTrue(server.startCalled)
+        XCTAssertFalse(server.methodGETCalled)
+
+        // WHEN: GET stub is updated
+        fileManager.contentsData = String(#"{"status": "ok"}"#).data(using: .utf8)
+        XCTAssertNoThrow(try sut.update(using: APIStubInfo(statusCode: 10, url: "", jsonFilename: "", method: .GET)))
+
+        // THEN: stub should be successfully registered to server
+        XCTAssertTrue(fileManager.fileExistsCalled)
+        XCTAssertTrue(fileManager.contentsCalled)
+        XCTAssertTrue(server.methodGETCalled)
+    }
+
+    private func makeTestObjects() -> (FileManagerSpy, HttpServerSpy) {
+        let fileManager = FileManagerSpy()
+        let server = HttpServerSpy()
+        return (fileManager, server)
+    }
+
+    private func makeSUT(
+        fileManager: FileManagerSpy,
+        server: HttpServerSpy,
+        stubs: [APIStubInfo] = [],
+        appID: String = "12345",
+        port: APIConfiguration.PortType = .fixed(15),
+        maxPortRetries: Int = 1
+    ) throws -> HTTPDynamicStubs {
+        try HTTPDynamicStubs(
+            fileManager: fileManager,
+            server: server,
+            initialStubs: stubs,
+            regexModifier: RegexJSONModifier(),
+            appID: appID,
+            port: port,
+            maxPortRetries: maxPortRetries
+        )
+    }
+}
+
+private final class FileManagerSpy: FileManaging {
+    enum Error: Swift.Error {
+        case failedToCreateDir
+    }
+
+    var failToCreateDirectory = false
+    func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]?) throws {
+        if failToCreateDirectory {
+            throw Error.failedToCreateDir
+        }
+    }
+
+    var fileExistsCalled = false
+    var filesDoesExist = true
+    func fileExists(atPath path: String) -> Bool {
+        fileExistsCalled = true
+        return filesDoesExist
+    }
+
+    var contentsCalled = false
+    var contentsData: Data?
+    func contents(atPath path: String) -> Data? {
+        contentsCalled = true
+        return contentsData
+    }
+}
+
+private final class HttpServerSpy: HttpServerProtocol {
+    var methodDELETECalled = false
+    func methodDELETE(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        methodDELETECalled = true
+    }
+
+    func methodPOST(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+
+    }
+
+    var methodGETCalled = false
+    func methodGET(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+        methodGETCalled = true
+    }
+
+    func methodPUT(path: String, response: ((HttpRequest) -> HttpResponse)?) {
+
+    }
+
+    var startCalled = false
+    func start(_ port: in_port_t, forceIPv4: Bool, priority: DispatchQoS.QoSClass) throws {
+        startCalled = true
+    }
+
+    var stopCalled = false
+    func stop() {
+        stopCalled = true
+    }
+}

--- a/TWUITestsTests/PortSettingsTests.swift
+++ b/TWUITestsTests/PortSettingsTests.swift
@@ -16,27 +16,27 @@ import XCTest
 @testable import TWUITests
 
 final class PortSettingsTests: XCTestCase {
-    func testFixedPortRetry() {
+    func testFixedPortRetry() throws {
         var sut = PortSettings(port: .fixed(1000), maxRetriesCount: 3)
         XCTAssertTrue(sut.canRetry)
         XCTAssertEqual(sut.maxRetriesCount, 3)
         XCTAssertEqual(sut.port, 1000)
-        sut.retry()
-        sut.retry()
-        sut.retry()
+        try sut.retry()
+        try sut.retry()
+        try sut.retry()
         XCTAssertFalse(sut.canRetry)
     }
 
-    func testFixedPortRangeRetry() {
+    func testFixedPortRangeRetry() throws {
         var sut = PortSettings(port: .range(0...10), maxRetriesCount: 3)
         XCTAssertTrue(sut.canRetry)
         XCTAssertEqual(sut.maxRetriesCount, 3)
         XCTAssertTrue((0...10).contains(sut.port))
-        sut.retry()
+        try sut.retry()
         XCTAssertTrue((0...10).contains(sut.port))
-        sut.retry()
+        try sut.retry()
         XCTAssertTrue((0...10).contains(sut.port))
-        sut.retry()
+        try sut.retry()
         XCTAssertFalse(sut.canRetry)
     }
 }

--- a/TWUITestsTests/RegexJSONModifierTests.swift
+++ b/TWUITestsTests/RegexJSONModifierTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 @testable import TWUITests
 
-class RegexJSONModifierTests: XCTestCase {
+final class RegexJSONModifierTests: XCTestCase {
 
     private var sut: RegexJSONModifier!
     private var jsonInput = """


### PR DESCRIPTION
Try - catch support is here 🎉 

Old `start()` and `update(using:)` are deprecated (still available).

New `startServer()` and `update(with:` throwable methods are introduced. 

Tests to cover http server `start` and `update` stubs implementation are added.