### PR TITLE
Introduce throwable replace methods

### DIFF
--- a/ExampleUITests/Home/HomeUITests.swift
+++ b/ExampleUITests/Home/HomeUITests.swift
@@ -18,8 +18,8 @@ import TWUITests
 final class HomeTests: UITestCase {
     func testAPIResponse() throws {
         try start(with: Configuration().isUser("hello@domain.com", password: "password")) { app in
-            app.replaceValues(
-                of: [
+            try app.replace(
+                keysAndValues: [
                     "result": "AUTHENTICATED"
                 ],
                 in: Stub.Authentication.success

--- a/ExampleUITests/Login/LoginUITests.swift
+++ b/ExampleUITests/Login/LoginUITests.swift
@@ -42,8 +42,8 @@ final class LoginUITests: UITestCase {
 
     func testAPIResponse() throws {
         try start(with: Configuration()) { app in
-            app.replaceValues(
-                of: [
+            try app.replace(
+                keysAndValues: [
                     "result": "NOT_AUTHENTICATED"
                 ],
                 in: Stub.Authentication.success

--- a/TWUITests.xcodeproj/project.pbxproj
+++ b/TWUITests.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 				70D2FF212271F9D4008B37F4 /* Sources */,
 				70D2FF222271F9D4008B37F4 /* Frameworks */,
 				70D2FF232271F9D4008B37F4 /* Resources */,
-				293F1D1B248F8DB000EC03C4 /* ShellScript */,
+				293F1D1B248F8DB000EC03C4 /* Copy API responses */,
 			);
 			buildRules = (
 			);
@@ -524,7 +524,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [ -x \"$(command -v swiftlint)\" ]; then\n    /usr/local/bin/swiftlint\nelse\n    echo \"Swiftlint not installed, skipping\"\nfi\n";
 		};
-		293F1D1B248F8DB000EC03C4 /* ShellScript */ = {
+		293F1D1B248F8DB000EC03C4 /* Copy API responses */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -533,6 +533,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Copy API responses";
 			outputFileListPaths = (
 			);
 			outputPaths = (

--- a/TWUITests/APIStubs/HTTPDynamicStubs.swift
+++ b/TWUITests/APIStubs/HTTPDynamicStubs.swift
@@ -16,12 +16,12 @@ import Foundation
 import Swifter
 
 protocol HTTPDynamicStubing {
-    func update(with stubInfo: APIStubInfo)
+    func update(with stubInfo: APIStubInfo) throws
     @available(*, deprecated, message: "Use throwable `startServer()` instead")
     func start() -> UInt16
     func startServer() throws -> UInt16
     func stop()
-    func replace(with: ReplacementJob)
+    func replace(with: ReplacementJob) throws
 }
 
 final class HTTPDynamicStubs: HTTPDynamicStubing {
@@ -97,25 +97,11 @@ final class HTTPDynamicStubs: HTTPDynamicStubing {
         server.stop()
     }
 
-    @available(*, deprecated, message: "Use throwable `update(using:)` instead")
-    func update(with stubInfo: APIStubInfo) {
-        try? setupStub(stubInfo)
-    }
-
-    func update(using stubInfo: APIStubInfo) throws {
+    func update(with stubInfo: APIStubInfo) throws {
         try setupStub(stubInfo)
     }
 
-    @available(*, deprecated, message: "Use throwable `replace(using:)` instead")
-    func replace(with job: ReplacementJob) {
-        try? transform({
-                try self.regexModifier.apply(modification: job.modification, in: $0)
-            },
-            in: job.stub
-        )
-    }
-
-    func replace(using job: ReplacementJob) throws {
+    func replace(with job: ReplacementJob) throws {
         try transform({
                 try self.regexModifier.apply(modification: job.modification, in: $0)
             },

--- a/TWUITests/Components/UITestApplication.swift
+++ b/TWUITests/Components/UITestApplication.swift
@@ -17,7 +17,7 @@ import XCTest
 public protocol XCUIApplicationStarter {
     @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
     func start(using configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?)
-    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws
+    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) throws -> Void)?) throws
 }
 
 public extension XCUIApplicationStarter {
@@ -119,7 +119,7 @@ extension UITestApplication: XCUIApplicationStarter {
     }
 
     // UI tests must launch the application that they test.
-    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws {
+    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) throws -> Void)?) throws {
         let port = try serverStart(with: configuration.apiConfiguration, initiationClosure: initiationClosure)
         configuration.update(port: port)
         set(configuration: configuration).launch()
@@ -127,7 +127,7 @@ extension UITestApplication: XCUIApplicationStarter {
 
     private func serverStart(
         with apiConfiguration: APIConfiguration,
-        initiationClosure: ((UITestApplication) -> Void)? = nil
+        initiationClosure: ((UITestApplication) throws -> Void)?
     ) throws -> UInt16 {
         let server = try HTTPDynamicStubs(appID: apiConfiguration.appID, port: apiConfiguration.port)
         let port = try server.startServer()
@@ -140,7 +140,7 @@ extension UITestApplication: XCUIApplicationStarter {
 
         // Call initiation closure if it's not nil
         if let initiation = initiationClosure {
-            initiation(self)
+            try initiation(self)
         }
 
         return port

--- a/TWUITests/Components/UITestCase.swift
+++ b/TWUITests/Components/UITestCase.swift
@@ -50,7 +50,7 @@ open class UITestCase: XCTestCase {
 }
 
 extension UITestCase: ApplicationStarter {
-    @available(*, deprecated, message: "Use throwable `start(with:initiationClosure:)` instead")
+    @available(*, deprecated, message: "Use throwable `start(with:)` instead")
     @discardableResult
     public func start(using configuration: Configuration) -> UITestApplication {
         app.start(using: configuration)

--- a/TWUITests/Components/UITestCase.swift
+++ b/TWUITests/Components/UITestCase.swift
@@ -16,7 +16,7 @@ import XCTest
 
 public protocol ApplicationStarter {
     func start(with configuration: Configuration) throws -> UITestApplication
-    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws -> UITestApplication
+    func start(with configuration: Configuration, initiationClosure: ((UITestApplication) throws -> Void)?) throws -> UITestApplication
 
     @available(*, deprecated, message: "Use throwable `start(with:)` instead")
     func start(using configuration: Configuration) -> UITestApplication
@@ -74,7 +74,7 @@ extension UITestCase: ApplicationStarter {
     ///   Use this param if you need to inject custom mocked API responses on app launch
     /// - Returns: UITestApplication
     @discardableResult
-    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) -> Void)?) throws -> UITestApplication {
+    public func start(with configuration: Configuration, initiationClosure: ((UITestApplication) throws -> Void)?) throws -> UITestApplication {
         try app.start(with: configuration, initiationClosure: initiationClosure)
         return app
     }

--- a/TWUITestsTests/HTTPDynamicStubsTests.swift
+++ b/TWUITestsTests/HTTPDynamicStubsTests.swift
@@ -69,7 +69,7 @@ final class HTTPDynamicStubsTests: XCTestCase {
 
         // WHEN: GET stub is updated
         fileManager.contentsData = String(#"{"status": "ok"}"#).data(using: .utf8)
-        XCTAssertNoThrow(try sut.update(using: APIStubInfo(statusCode: 10, url: "", jsonFilename: "", method: .GET)))
+        XCTAssertNoThrow(try sut.update(with: APIStubInfo(statusCode: 10, url: "", jsonFilename: "", method: .GET)))
 
         // THEN: stub should be successfully registered to server
         XCTAssertTrue(fileManager.fileExistsCalled)


### PR DESCRIPTION
Introduce throwable `replace` methods.
Deprecate old replace methods.
Make sure it is backwards compatible.
